### PR TITLE
Switch renovate config to PinguApps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>OmniaBI/renovate-config"
+    "local>PinguApps/renovate-config"
   ]
 }


### PR DESCRIPTION
Update renovate.json to extend the local>PinguApps/renovate-config instead of local>OmniaBI/renovate-config. This points Renovate to the new shared configuration for dependency automation.

# Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [ ] `bug`
- [ ] `docs`
- [x] `security`
- [ ] `meta`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

# Summary
This pull request updates the Renovate configuration to use a different shared config. The project now extends from the `PinguApps/renovate-config` configuration instead of `OmniaBI/renovate-config`.