### PR TITLE
Rename rule and diagnostic IDs to avoid namespace collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ RazorStyle is an opinionated formatter and linter for Blazor `.razor` files. It 
 - [Build Integration](#build-integration)
 - [CLI Usage](#cli-usage)
 - [Rules](#rules)
-  - [RS0001 Attribute Wrapping](#rs0001-attribute-wrapping)
-  - [RS0002 Child Content Lines](#rs0002-child-content-lines)
-  - [RS0003 Attribute Order](#rs0003-attribute-order)
+  - [PARS0001 Attribute Wrapping](#pars0001-attribute-wrapping)
+  - [PARS0002 Child Content Lines](#pars0002-child-content-lines)
+  - [PARS0003 Attribute Order](#pars0003-attribute-order)
 
 ## Packages
 
@@ -45,9 +45,9 @@ Override behaviour with MSBuild properties:
 <PropertyGroup>
   <RazorStyleEnabled>true</RazorStyleEnabled>
   <RazorStyleCommand>check</RazorStyleCommand>
-  <DisableRS0001>false</DisableRS0001>
-  <DisableRS0002>false</DisableRS0002>
-  <DisableRS0003>false</DisableRS0003>
+  <DisablePARS0001>false</DisablePARS0001>
+  <DisablePARS0002>false</DisablePARS0002>
+  <DisablePARS0003>false</DisablePARS0003>
 </PropertyGroup>
 ```
 
@@ -78,20 +78,20 @@ razorstyle fix .\src
 Disable specific rules for a run:
 
 ```powershell
-razorstyle check .\src --disable RS0001 --disable RS0003
+razorstyle check .\src --disable PARS0001 --disable PARS0003
 ```
 
 Use the CLI when you want direct control over when RazorStyle runs. It is a good fit for local cleanup, manual checks before opening a PR, custom CI steps, and scripts that should target a particular folder.
 
 ## Rules
 
-- `RS0001`: start-tag attributes must wrap and align consistently.
-- `RS0002`: child content must appear on its own line.
-- `RS0003`: attributes must follow the preferred RazorStyle order.
+- `PARS0001`: start-tag attributes must wrap and align consistently.
+- `PARS0002`: child content must appear on its own line.
+- `PARS0003`: attributes must follow the preferred RazorStyle order.
 
-### RS0001 Attribute Wrapping
+### PARS0001 Attribute Wrapping
 
-`RS0001` keeps multi-attribute start tags readable by putting each additional attribute on its own aligned line. Tags with no attributes, or with a single attribute, stay inline so simple markup remains compact.
+`PARS0001` keeps multi-attribute start tags readable by putting each additional attribute on its own aligned line. Tags with no attributes, or with a single attribute, stay inline so simple markup remains compact.
 
 Before:
 
@@ -114,9 +114,9 @@ Single-attribute and attribute-free tags remain inline:
 <Modal Title="Hello" />
 ```
 
-### RS0002 Child Content Lines
+### PARS0002 Child Content Lines
 
-`RS0002` separates child content from the opening and closing tags. This makes inline element bodies easier to scan, gives nested markup room to breathe, and avoids small edits turning into noisy one-line diffs.
+`PARS0002` separates child content from the opening and closing tags. This makes inline element bodies easier to scan, gives nested markup room to breathe, and avoids small edits turning into noisy one-line diffs.
 
 Before:
 
@@ -139,9 +139,9 @@ Self-closing tags are already valid:
 <span class="foo" />
 ```
 
-### RS0003 Attribute Order
+### PARS0003 Attribute Order
 
-`RS0003` applies a stable attribute order so the important identity, styling, binding, event, content, accessibility, and fallback attributes appear in a predictable place. In broad terms, unique identity-style attributes such as `@key`, `@ref`, `name`, and `id` come first, followed by `class` and `style`, binding and value-related attributes, event callbacks, common HTML/component attributes, templated or child-content attributes, general attributes, `aria-*`, `data-*`, splatted `@attributes`, and boolean or conditional attributes near the end.
+`PARS0003` applies a stable attribute order so the important identity, styling, binding, event, content, accessibility, and fallback attributes appear in a predictable place. In broad terms, unique identity-style attributes such as `@key`, `@ref`, `name`, and `id` come first, followed by `class` and `style`, binding and value-related attributes, event callbacks, common HTML/component attributes, templated or child-content attributes, general attributes, `aria-*`, `data-*`, splatted `@attributes`, and boolean or conditional attributes near the end.
 
 Before:
 

--- a/src/PinguApps.RazorStyle.Build/buildTransitive/PinguApps.RazorStyle.props
+++ b/src/PinguApps.RazorStyle.Build/buildTransitive/PinguApps.RazorStyle.props
@@ -3,8 +3,8 @@
     <RazorStyleEnabled Condition="'$(RazorStyleEnabled)' == ''">true</RazorStyleEnabled>
     <RazorStyleCommand Condition="'$(RazorStyleCommand)' == '' and '$(ContinuousIntegrationBuild)' == 'true'">check</RazorStyleCommand>
     <RazorStyleCommand Condition="'$(RazorStyleCommand)' == ''">fix</RazorStyleCommand>
-    <DisableRS0001 Condition="'$(DisableRS0001)' == ''">false</DisableRS0001>
-    <DisableRS0002 Condition="'$(DisableRS0002)' == ''">false</DisableRS0002>
-    <DisableRS0003 Condition="'$(DisableRS0003)' == ''">false</DisableRS0003>
+    <DisablePARS0001 Condition="'$(DisablePARS0001)' == ''">false</DisablePARS0001>
+    <DisablePARS0002 Condition="'$(DisablePARS0002)' == ''">false</DisablePARS0002>
+    <DisablePARS0003 Condition="'$(DisablePARS0003)' == ''">false</DisablePARS0003>
   </PropertyGroup>
 </Project>

--- a/src/PinguApps.RazorStyle.Build/buildTransitive/PinguApps.RazorStyle.targets
+++ b/src/PinguApps.RazorStyle.Build/buildTransitive/PinguApps.RazorStyle.targets
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <RazorStyleCliPath Condition="'$(RazorStyleCliPath)' == ''">$(MSBuildThisFileDirectory)..\tools\net10.0\PinguApps.RazorStyle.Cli.dll</RazorStyleCliPath>
     <RazorStyleDisabledRuleArguments></RazorStyleDisabledRuleArguments>
-    <RazorStyleDisabledRuleArguments Condition="'$(DisableRS0001)' == 'true'">$(RazorStyleDisabledRuleArguments) --disable RS0001</RazorStyleDisabledRuleArguments>
-    <RazorStyleDisabledRuleArguments Condition="'$(DisableRS0002)' == 'true'">$(RazorStyleDisabledRuleArguments) --disable RS0002</RazorStyleDisabledRuleArguments>
-    <RazorStyleDisabledRuleArguments Condition="'$(DisableRS0003)' == 'true'">$(RazorStyleDisabledRuleArguments) --disable RS0003</RazorStyleDisabledRuleArguments>
+    <RazorStyleDisabledRuleArguments Condition="'$(DisablePARS0001)' == 'true'">$(RazorStyleDisabledRuleArguments) --disable PARS0001</RazorStyleDisabledRuleArguments>
+    <RazorStyleDisabledRuleArguments Condition="'$(DisablePARS0002)' == 'true'">$(RazorStyleDisabledRuleArguments) --disable PARS0002</RazorStyleDisabledRuleArguments>
+    <RazorStyleDisabledRuleArguments Condition="'$(DisablePARS0003)' == 'true'">$(RazorStyleDisabledRuleArguments) --disable PARS0003</RazorStyleDisabledRuleArguments>
   </PropertyGroup>
 
   <Target Name="RunRazorStyle"

--- a/src/PinguApps.RazorStyle.Cli/Program.cs
+++ b/src/PinguApps.RazorStyle.Cli/Program.cs
@@ -9,14 +9,14 @@ app.Configure(config =>
     config.AddCommand<CheckCommand>("check")
         .WithDescription("Checks Razor files for RazorStyle rule violations.")
         .WithExample(["check", "./src"])
-        .WithExample(["check", "./src", "--disable", "RS0001"])
-        .WithExample(["check", "./src", "--disable", "RS0001", "--disable", "RS0002"]);
+        .WithExample(["check", "./src", "--disable", "PARS0001"])
+        .WithExample(["check", "./src", "--disable", "PARS0001", "--disable", "PARS0002"]);
 
     config.AddCommand<FixCommand>("fix")
         .WithDescription("Fixes RazorStyle rule violations in Razor files.")
         .WithExample(["fix", "./src"])
-        .WithExample(["fix", "./src", "--disable", "RS0002"])
-        .WithExample(["fix", "./src", "--disable", "RS0002", "--disable", "RS0003"]);
+        .WithExample(["fix", "./src", "--disable", "PARS0002"])
+        .WithExample(["fix", "./src", "--disable", "PARS0002", "--disable", "PARS0003"]);
 });
 
 return app.Run(args);

--- a/src/PinguApps.RazorStyle.Core/Rules/AttributeOrderRule.cs
+++ b/src/PinguApps.RazorStyle.Core/Rules/AttributeOrderRule.cs
@@ -10,7 +10,7 @@ public sealed class AttributeOrderRule : IRazorStyleRule
     /// <summary>
     /// The rule identifier.
     /// </summary>
-    public const string DiagnosticId = "RS0003";
+    public const string DiagnosticId = "PARS0003";
 
     /// <inheritdoc />
     string IRazorStyleRule.DiagnosticId => DiagnosticId;

--- a/src/PinguApps.RazorStyle.Core/Rules/AttributeWrappingRule.cs
+++ b/src/PinguApps.RazorStyle.Core/Rules/AttributeWrappingRule.cs
@@ -8,7 +8,7 @@ public sealed class AttributeWrappingRule : IRazorStyleRule
     /// <summary>
     /// The rule identifier.
     /// </summary>
-    public const string DiagnosticId = "RS0001";
+    public const string DiagnosticId = "PARS0001";
 
     private readonly AttributeWrappingFixer _fixer = new();
 

--- a/src/PinguApps.RazorStyle.Core/Rules/ChildContentLineRule.cs
+++ b/src/PinguApps.RazorStyle.Core/Rules/ChildContentLineRule.cs
@@ -8,7 +8,7 @@ public sealed class ChildContentLineRule : IRazorStyleRule
     /// <summary>
     /// The rule identifier.
     /// </summary>
-    public const string DiagnosticId = "RS0002";
+    public const string DiagnosticId = "PARS0002";
 
     /// <inheritdoc />
     string IRazorStyleRule.DiagnosticId => DiagnosticId;

--- a/tests/PinguApps.RazorStyle.Tests/Features/RazorStyleRules.feature
+++ b/tests/PinguApps.RazorStyle.Tests/Features/RazorStyleRules.feature
@@ -72,7 +72,7 @@ Feature: Razor style rules
       <Foo Param="Bar" Param2="Baz" />
       """
     When RazorStyle check runs
-    Then RazorStyle should report "RS0001"
+    Then RazorStyle should report "PARS0001"
     And RazorStyle should report "Each attribute after the first must begin on a new line."
 
   @razorstyle
@@ -97,7 +97,7 @@ Feature: Razor style rules
       <span>Some text</span>
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0002"
+    Then RazorStyle should report "PARS0002"
     And the rewritten Razor source should be
       """
       <span>
@@ -113,7 +113,7 @@ Feature: Razor style rules
       </div>
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0002"
+    Then RazorStyle should report "PARS0002"
     And the rewritten Razor source should be
       """
       <div>
@@ -140,7 +140,7 @@ Feature: Razor style rules
       <Panel><Panel /></Panel>
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0002"
+    Then RazorStyle should report "PARS0002"
     And the rewritten Razor source should be
       """
       <Panel>
@@ -157,7 +157,7 @@ Feature: Razor style rules
       </PanelHeader></Panel>
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0002"
+    Then RazorStyle should report "PARS0002"
     And the rewritten Razor source should be
       """
       <Panel>
@@ -176,7 +176,7 @@ Feature: Razor style rules
       </script></div>
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0002"
+    Then RazorStyle should report "PARS0002"
     And the rewritten Razor source should be
       """
       <div>
@@ -193,7 +193,7 @@ Feature: Razor style rules
       <div>@("</div>")</div>
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0002"
+    Then RazorStyle should report "PARS0002"
     And the rewritten Razor source should be
       """
       <div>
@@ -208,7 +208,7 @@ Feature: Razor style rules
       <div>@{ var text = "</div>"; }</div>
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0002"
+    Then RazorStyle should report "PARS0002"
     And the rewritten Razor source should be
       """
       <div>
@@ -223,7 +223,7 @@ Feature: Razor style rules
       <div>@Format("</div>")</div>
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0002"
+    Then RazorStyle should report "PARS0002"
     And the rewritten Razor source should be
       """
       <div>
@@ -238,7 +238,7 @@ Feature: Razor style rules
       <button data-track="save" disabled class="btn" @onclick="Save" id="save-button" />
       """
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0003"
+    Then RazorStyle should report "PARS0003"
     And the rewritten Razor source should be
       """
       <button id="save-button"
@@ -254,9 +254,9 @@ Feature: Razor style rules
       """
       <button class="btn" id="save-button" />
       """
-    And RazorStyle rule "RS0001" is disabled
+    And RazorStyle rule "PARS0001" is disabled
     When RazorStyle fix runs
-    Then RazorStyle should report "RS0003"
+    Then RazorStyle should report "PARS0003"
     And the rewritten Razor source should be
       """
       <button id="save-button" class="btn" />
@@ -297,7 +297,7 @@ Feature: Razor style rules
       """
       <Foo Param="Bar" Param2="Baz" />
       """
-    And RazorStyle rule "RS0001" is disabled
+    And RazorStyle rule "PARS0001" is disabled
     When RazorStyle check runs
     Then no RazorStyle diagnostics should be reported
     When RazorStyle fix runs


### PR DESCRIPTION
# Categorise the PR
<!-- Select at least one category from below that best describes this PR and what it does -->
- [ ] `feature`
- [ ] `bug`
- [x] `docs`
- [ ] `security`
- [x] `meta`
- [ ] `patch`
- [ ] `minor`
- [x] `major`

# Summary
This pull request updates the naming convention for all RazorStyle rule identifiers from the old `RS0001`, `RS0002`, and `RS0003` format to the new `PARS0001`, `PARS0002`, and `PARS0003` format. This change is applied consistently across the codebase, build integration, CLI usage, documentation, and tests to ensure clarity and avoid confusion with other tools.

The most important changes include:

**Rule Identifier Renaming (Core Functionality & Code):**
* Updated the `DiagnosticId` constants in `AttributeWrappingRule`, `ChildContentLineRule`, and `AttributeOrderRule` from `RS0001`, `RS0002`, and `RS0003` to `PARS0001`, `PARS0002`, and `PARS0003` respectively. [[1]](diffhunk://#diff-847d59f1be811b3d86b592434d5b8b810daf9636b7bf235fea1ad9c8df26bd31L11-R11) [[2]](diffhunk://#diff-3612f0d068219fd8bb14af026313b07848e36665a304caec5f72cee40d8ea235L11-R11) [[3]](diffhunk://#diff-d2aba573ada633989ea03c5592a52b31792382ecff91a951b8c2414e362fef7aL13-R13)

**Build Integration:**
* Changed all MSBuild property and target references from `DisableRS0001/2/3` to `DisablePARS0001/2/3` in `.props` and `.targets` files, and updated the logic for passing disabled rule arguments to the CLI. [[1]](diffhunk://#diff-0ef8d51e70ad938a5d04ba97f0b84da67c7f0d409ac77f6425c3f697d340497eL6-R8) [[2]](diffhunk://#diff-83c18ec2cf4bea9f2fd3d647762860e648fbe1ce351606da9c5c3f4da15cfed0L5-R7)

**CLI Usage and Examples:**
* Updated all CLI command examples in `Program.cs` and `README.md` to use the new `PARS000x` rule identifiers. [[1]](diffhunk://#diff-79200fc2f14002eb21a1018f61124fe5c5cb21b7d0cc8c2e6b969a9ae6e35bb2L12-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R94)

**Documentation:**
* Revised the documentation in `README.md` to reference the new rule identifiers, including section headings, rule explanations, and configuration instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R94) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-R119) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R144)

**Tests:**
* Updated all feature test steps and assertions in `RazorStyleRules.feature` to use the new `PARS000x` identifiers, ensuring tests remain valid and descriptive. [[1]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L75-R75) [[2]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L100-R100) [[3]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L116-R116) [[4]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L143-R143) [[5]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L160-R160) [[6]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L179-R179) [[7]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L196-R196) [[8]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L211-R211) [[9]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L226-R226) [[10]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L241-R241) [[11]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L257-R259) [[12]](diffhunk://#diff-fc01db6c41d06760698dfa87dac8d8bd975abaf12216518ff1d78898367b8194L300-R300)

These changes help standardize rule naming and reduce ambiguity throughout the project.